### PR TITLE
Switched from build.sh to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: build test clean
+
+BIN=clarawm
+CFLAGS=-lX11 -O2 -Wall -Werror
+CC=clang
+CSRC=$(wildcard *.c)
+
+build: $(BIN)
+
+$(BIN): $(CSRC)
+	$(CC) $(CSRC) -o $(BIN) $(CFLAGS)
+
+test:
+	Xephyr -ac -screen 800x600 -br -reset -terminate :1 &
+	sleep .5
+	DISPLAY=:1 ./$(BIN)
+
+clean:
+	rm $(BIN)

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-clang clarawm.c -o clarawm -lX11 -O2 -Wall -Werror &&
-if [[ "$*" == "run" ]]
-then
-    Xephyr -ac -screen 800x600 -br -reset -terminate :1 &
-    sleep .5
-    DISPLAY=:1 ./clarawm
-fi


### PR DESCRIPTION
Removed build.sh, added Makefile.
Makefile will be easier to maintain compared to a shell script (especially when more files appear).